### PR TITLE
Test/pipeline container def

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ test-bot:
     - pip install -r requirements.txt
     - export bot_environment=ci-tests
     - python bot.py &
-    - python bot_test.py --channel 720200786167988297 --run all $TARGET_BOT_ID $TESTER_BOT_TOKEN
+    - python bot_test.py --channel $CHANNEL_ID --run all $TARGET_BOT_ID $TESTER_BOT_TOKEN
 
 # Build an image, only on the master branch, and push to AWS Elastic Container Registry (ECR)
 build-image:

--- a/.tf/info.tf
+++ b/.tf/info.tf
@@ -7,7 +7,7 @@ data "aws_subnet_ids" "default" {
 }
 
 data "template_file" "discord_bot_app" {
-  template = file("policies/task-def.json")
+  template = file("policies/container-def.json")
   vars = {
     tag      = "latest"
     app_port = 3000

--- a/.tf/policies/container-def.json
+++ b/.tf/policies/container-def.json
@@ -1,0 +1,28 @@
+[
+    {
+      "name": "discord_movie_bot",
+      "image": "268906218954.dkr.ecr.eu-west-2.amazonaws.com/discord-movie-bot:testing-latest",
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "discord-movie-bot",
+          "awslogs-group": "awslogs-discord-movie-vote-bot"
+        }
+      },
+      "cpu": 256,
+      "ulimits": [
+        {
+          "name": "core",
+          "softLimit": 512,
+          "hardLimit": 512
+        }
+      ],
+      "mountPoints": [],
+      "memory": 512,
+      "volumesFrom": []
+  
+    }
+  ]
+  

--- a/bot.py
+++ b/bot.py
@@ -209,7 +209,8 @@ class MyClient(discord.Client):
 
     async def __end_test(self, message):
         if message.author.id == 763492591303655434 or message.author.id == 187697230767980545:
-            await self.channel_message("Closing...")
+            white_check_mark_unicode_character = "✅"
+            await message.add_reaction(white_check_mark_unicode_character)
             await self.close()
 
     # Wrapper function for sending a message into the relevant channel, this is always the same designated channel e.g. #movie-voting

--- a/bot.py
+++ b/bot.py
@@ -129,7 +129,7 @@ class MyClient(discord.Client):
 
                 elif self.check_key_error(choices):
                     await self.channel_message(
-                        f"{message.author.mention}, you're a cunt :) ."
+                        f"{message.author.mention}, you cannot vote for something outside of the list."
                     )
                     return
 

--- a/bot.py
+++ b/bot.py
@@ -76,15 +76,14 @@ class MyClient(discord.Client):
     async def new_vote(self, message):
 
         if "Admin" in [role.name for role in message.author.roles]:
-            movies = message.content.replace("!newvote ", "").split(", ")
+            movies = message.content.replace("!newvote ", "").split(",")
             for i, movie in enumerate(movies, start=1):
                 self.votes[i] = {"Movie Name": movie, "Vote Count": 0}
 
             movie_string = ""
-            i = 1
-            for movie in self.votes.values():
-                movie_string += f"{i}: {movie['Movie Name']}\n"
-                i += 1
+            
+            for index, movie in enumerate(self.votes.values(), start=1):
+                movie_string += f"{index}: {movie['Movie Name']}\n"
 
             await self.channel_message(
                 f"Use `!vote X Y Z` to place your votes\nChanges to votes are done by using `!changevote X Y Z`\n Movies to vote on: \n {movie_string}"

--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,9 @@ class MyClient(discord.Client):
             elif message.content.startswith("!changevote"):
                 await self.change_vote(message)
 
+            elif message.content == "!endtest":
+                await self.__end_test(message)
+
             elif "!endvote" in message.content:
 
                 if "Admin" in [role.name for role in message.author.roles]:
@@ -202,6 +205,12 @@ class MyClient(discord.Client):
         await self.channel_message(f"{message.author.mention} vote changed.")
         await self.standings_display()
         print("Vote changed: ", message_author)
+
+
+    async def __end_test(self, message):
+        if message.author.id == 763492591303655434 or message.author.id == 187697230767980545:
+            await self.channel_message("Closing...")
+            await self.close()
 
     # Wrapper function for sending a message into the relevant channel, this is always the same designated channel e.g. #movie-voting
     async def channel_message(self, message):

--- a/bot_test.py
+++ b/bot_test.py
@@ -36,9 +36,8 @@ async def test_finish_voting(interface):
 
 @test_collector()
 async def test_close_bot(interface):
-    bot_command = "!endtest"
-
-    await interface.assert_reply_contains(bot_command, "Closing...")
+    white_check_mark_unicode_character = "✅"
+    await interface.assert_reaction_equals("!endtest", white_check_mark_unicode_character) 
 
 if __name__ == "__main__":
     run_dtest_bot(sys.argv, test_collector)

--- a/bot_test.py
+++ b/bot_test.py
@@ -29,11 +29,16 @@ async def test_movie_vote(interface):
 
 
 @test_collector()
-async def test_cleanup(interface):
+async def test_finish_voting(interface):
     bot_command = "!endvote"
 
     await interface.assert_reply_contains(bot_command, "wins with")
 
+@test_collector()
+async def test_close_bot(interface):
+    bot_command = "!endtest"
+
+    await interface.assert_reply_contains(bot_command, "Closing...")
 
 if __name__ == "__main__":
     run_dtest_bot(sys.argv, test_collector)


### PR DESCRIPTION
- Changed container definition inside of `.tf/policies` to include specific `container-def.json`.
- Added minor adjustment to ending tests, special `!endtest` command which can only be called by me or the test bot. This ends the connection to Discord to stop a hanging process in the CI.
- Added `gitlab-ci-tests` channel in Discord for tests, updated the `CHANNEL_ID` to reflect this.